### PR TITLE
[TASK] Fix code formatting in LanguageOverride docs

### DIFF
--- a/Documentation/Loader/LanguageOverride.rst
+++ b/Documentation/Loader/LanguageOverride.rst
@@ -5,11 +5,11 @@
 Language Override
 ^^^^^^^^^^^^^^^^^
 
-Use this loader to create "locallangXMLOverride" configurations for language files. Recreate the same folder structure of the extension whose language files you want to override within `Resources/Private/Language/Overrides`. The first level is the extension name (`UpperCamelCase`). For XLIFF files language prefixes like `de.locallang_mod.xlf` are supported to register overrides for translations.
+Use this loader to create "locallangXMLOverride" configurations for language files. Recreate the same folder structure of the extension whose language files you want to override within :code:`Resources/Private/Language/Overrides`. The first level is the extension name (:code:`UpperCamelCase`). For XLIFF files language prefixes like :code:`de.locallang_mod.xlf` are supported to register overrides for translations.
 
-For example to override `EXT:foo_bar/mod1/locallang_mod.xlf` just create the file `Resources/Private/Language/Overrides/FooBar/mod1/locallang_mod.xlf` and fill it with language entries. To override `EXT:foo_bar/mod1/de.locallang_mod.xlf` create  `Resources/Private/Language/Overrides/FooBar/mod1/de.locallang_mod.xlf`.
+For example to override :code:`EXT:foo_bar/mod1/locallang_mod.xlf` just create the file :code:`Resources/Private/Language/Overrides/FooBar/mod1/locallang_mod.xlf` and fill it with language entries. To override :code:`EXT:foo_bar/mod1/de.locallang_mod.xlf` create :code:`Resources/Private/Language/Overrides/FooBar/mod1/de.locallang_mod.xlf`.
 
-Even if an extension follows the usual `Resources/Private/Language` structure, you still have to recreate that structure within `Resources/Private/Language/Overrides`, e.g. `Resources/Private/Language/Overrides/BazQux/Resources/Private/Language/locallang.xlf`.
+Even if an extension follows the usual :code:`Resources/Private/Language` structure, you still have to recreate that structure within :code:`Resources/Private/Language/Overrides`, e.g. :code:`Resources/Private/Language/Overrides/BazQux/Resources/Private/Language/locallang.xlf`.
 
 Internally the following kind of configuration will be generated:
 


### PR DESCRIPTION
Use reStructured Text syntax, not Markdown.