### PR TITLE
Exclude example code from classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,11 @@
   "autoload": {
     "psr-4": {
       "HDNET\\Autoloader\\": "Classes/"
-    }
+    },
+    "exclude-from-classmap": [
+      "/Resources/Private/Examples/", 
+      "/Resources/Private/Contrib/vendor/piotrooo/wsdl-creator/examples/"
+    ]
   },
   "keywords": [
     "TYPO3 CMS",


### PR DESCRIPTION
If using composer to install autoloader the included example code is added to classmap as well.
This produces several php exceptions.
To prevent this, there path must be added to the "exclude-from-classmap" section.