### PR TITLE
Add version to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
   "name": "lochmueller/autoloader",
+  "version": "2.0.0",
   "type": "typo3-cms-extension",
   "description": "Automatic components loading of ExtBase extensions to get more time for coffee in the company ;) This ext is not a PHP SPL autoloader or class loader - it is better! Loads CommandController, Xclass, Hooks, Aspects, FlexForms, Slots, TypoScript, TypeConverter, BackendLayouts and take care of createing needed templates, TCA configuration or translations at the right location.",
   "autoload": {


### PR DESCRIPTION
to be compatible to 6.2, the version must be added to the composer.json as well! in 7.x it is not needed anymore