### PR TITLE
Fix side effect with typo3_console in LanguageHandler

### DIFF
--- a/Classes/Localization/LanguageHandler.php
+++ b/Classes/Localization/LanguageHandler.php
@@ -40,7 +40,8 @@ class LanguageHandler extends LanguageStore
      */
     public function handle($key, $extensionName, &$default, $arguments, $overrideLanguageBase = null)
     {
-        if (!($GLOBALS['TYPO3_DB'] instanceof DatabaseConnection)) {
+        // If we are called early in the TYPO3 bootstrap we mus return early with the default label
+        if (!($GLOBALS['TYPO3_DB'] instanceof DatabaseConnection) || empty($GLOBALS['TCA'])) {
             return $default;
         }
         $value = LocalizationUtility::translate($key, $extensionName, $arguments);


### PR DESCRIPTION
The LanguageHandler can be called early in the bootstrap,
when DB of TCA might not be ready. The first is the case
for a regular TYPO3 bootstrap, the latter during early boot
of typo3_console, where DB is available, but TCA is not.