### PR TITLE
[FIXED] Keep the sorting of non priority Slots

### DIFF
--- a/Classes/Loader/Slots.php
+++ b/Classes/Loader/Slots.php
@@ -66,18 +66,17 @@ class Slots implements LoaderInterface
                     $priority = isset($tagConfiguration['signalPriority'][$key]) ? $tagConfiguration['signalPriority'][$key] : 0;
                     $priority = MathUtility::forceIntegerInRange($priority, 0, 100);
 
-                    $slots[] = [
+                    $slots[$priority][] = [
                         'signalClassName' => trim($signalClass, '\\'),
                         'signalName' => $tagConfiguration['signalName'][$key],
                         'slotClassNameOrObject' => $slotClass,
                         'slotMethodName' => $methodReflection->getName(),
-                        'priority' => $priority,
                     ];
                 }
             }
         }
 
-        $slots = $this->sortSlotsByPriority($slots);
+        $slots = $this->flattenSlotsByPriority($slots);
 
         return $slots;
     }
@@ -86,16 +85,16 @@ class Slots implements LoaderInterface
      * @param array $slots
      * @return array
      */
-    public function sortSlotsByPriority(array $slots) {
-        usort($slots, function ($slotA, $slotB) {
-            if ($slotA['priority'] == $slotB['priority']) {
-                return 0;
+    public function flattenSlotsByPriority(array $array) {
+        krsort($array);
+        $result = [];
+        foreach($array as $priority => $slots) {
+            foreach($slots as $slot) {
+                $result[] = $slot;
             }
+        }
 
-            return ($slotA['priority'] < $slotB['priority']) ? 1 : -1;
-        });
-
-        return $slots;
+        return $result;
     }
 
     /**

--- a/Tests/Unit/Loader/SlotTest.php
+++ b/Tests/Unit/Loader/SlotTest.php
@@ -18,23 +18,31 @@ class SlotTest extends UnitTestCase
         $slots = new Slots();
 
         $data = [
-            ['element' => 1, 'priority' => 50],
-            ['element' => 2, 'priority' => 0],
-            ['element' => 3, 'priority' => 0],
-            ['element' => 4, 'priority' => 100],
-            ['element' => 5, 'priority' => 0],
-            ['element' => 6, 'priority' => 20],
+            50 => [
+                ['element' => 1],
+            ],
+            0 => [
+                ['element' => 2],
+                ['element' => 3],
+                ['element' => 5],
+            ],
+            100 => [
+                ['element' => 4]
+            ],
+            20 => [
+                ['element' => 6],
+            ],
         ];
 
-        $result = $slots->sortSlotsByPriority($data);
+        $result = $slots->flattenSlotsByPriority($data);
 
         $expected = [
-            ['element' => 4, 'priority' => 100],
-            ['element' => 1, 'priority' => 50],
-            ['element' => 6, 'priority' => 20],
-            ['element' => 2, 'priority' => 0],
-            ['element' => 3, 'priority' => 0],
-            ['element' => 5, 'priority' => 0],
+            ['element' => 4],
+            ['element' => 1],
+            ['element' => 6],
+            ['element' => 2],
+            ['element' => 3],
+            ['element' => 5],
         ];
 
         $this->assertSame($expected, $result);


### PR DESCRIPTION
We should now be back to normal AND have the
possibility to add @signalPriority to Slots.

Sadly we can NOT use usort for this kind of
sorting because Zends Bubblesort is always
unstable and we can't predict the sorting
for equal priorities.

See: http://php.net/manual/en/function.usort.php

Fixes #57