### PR TITLE
[BUGFIX] - Ampersand encoded in SoapServer->getServiceUrl

### DIFF
--- a/Classes/Service/SoapServer.php
+++ b/Classes/Service/SoapServer.php
@@ -116,7 +116,7 @@ class SoapServer
     {
         $uri = GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL');
         $parts = parse_url($uri);
-        $parts['query'] = 'eID=SoapServer&server=' . $this->serverKey;
+        $parts['query'] = 'eID=SoapServer&amp;server=' . $this->serverKey;
         return HttpUtility::buildUrl($parts);
     }
 }


### PR DESCRIPTION
The ampersand in XML must be encoded as &amp;amp;. If not, some soap clients fail to parse the soap response.