### PR TITLE
Update Language.php

### DIFF
--- a/Classes/DataSet/Language.php
+++ b/Classes/DataSet/Language.php
@@ -54,6 +54,7 @@ class Language implements DataSetInterface
                     'config' => [
                         'type' => 'select',
                         'renderType' => 'selectSingle',
+                        'default' => 0,
                         'items' => [
                             [
                                 '',


### PR DESCRIPTION
Setting default => 0 for l10n_parent. Without it, it causes an error in the filelist module if you try to copy and paste a record (on some machines)