### PR TITLE
Fix retrieval of property tags

### DIFF
--- a/Classes/Utility/ReflectionUtility.php
+++ b/Classes/Utility/ReflectionUtility.php
@@ -179,7 +179,11 @@ class ReflectionUtility
     public static function getTagConfigurationForProperty(string $className, string $property, array $tagNames): array
     {
         $reflectionService = self::getReflectionService();
-        $tags = $reflectionService->getClassSchema($className)->getProperty($property)['tags'];
+        if (self::is9orHigher()) {
+            $tags = $reflectionService->getClassSchema($className)->getProperty($property)['tags'];
+        } else {
+            $tags = $reflectionService->getPropertyTagsValues($className, $property);
+        }
 
         $configuration = [];
         foreach ($tagNames as $tagName) {


### PR DESCRIPTION
Reflection of properties has changed in TYPO3 9, so the code must be adaptive to the TYPO3 version used.