### PR TITLE
Generated SQL will wrap column names in backticks

### DIFF
--- a/Classes/Service/SmartObjectInformationService.php
+++ b/Classes/Service/SmartObjectInformationService.php
@@ -231,7 +231,7 @@ class SmartObjectInformationService
                     // Do not handle the getDatabaseMappingByVarType by db, Fallback is the var call
                 }
             }
-            $fields[] = $info['name'] . ' ' . $info['db'];
+            $fields[] = '`' . $info['name'] . '` ' . $info['db'];
         }
 
         return $fields;


### PR DESCRIPTION
Hi Tim,

this is a quick fix for me. Do you think we should work on this a bit more?

Commit message:

> This will prevent errors within the generated SQL when magic words are used as column names. For example 'key' oder 'default'.

Cheers