### PR TITLE
LanguageHandler issue. No $GLOBALS['TYPO3_REQUEST']

### DIFF
--- a/Classes/Localization/LanguageHandler.php
+++ b/Classes/Localization/LanguageHandler.php
@@ -8,6 +8,7 @@ declare(strict_types = 1);
 namespace HDNET\Autoloader\Localization;
 
 use HDNET\Autoloader\Localization\Writer\AbstractLocalizationWriter;
+use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Localization\LanguageStore;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
@@ -37,7 +38,7 @@ class LanguageHandler extends LanguageStore
      */
     public function handle($key, $extensionName, $default, $arguments, $overrideLanguageBase = null)
     {
-        // If we are called early in the TYPO3 bootstrap we mus return early with the default label
+        // If we are called early in the TYPO3 bootstrap we must return early with the default label
         if (empty($GLOBALS['TCA'])) {
             return $default;
         }
@@ -47,10 +48,11 @@ class LanguageHandler extends LanguageStore
             $GLOBALS['LANG']->init($GLOBALS['BE_USER']->uc['lang']);
         }
 
-        $value = LocalizationUtility::translate($key, $extensionName, $arguments);
-
-        if (null !== $value) {
-            return $value;
+        // LocalizationUtility::translate() throws exception if $GLOBALS['TYPO3_REQUEST'] is not instanceof ServerRequestInterface.
+        if ($GLOBALS['TYPO3_REQUEST'] instanceof ServerRequestInterface) {
+            if($value = LocalizationUtility::translate($key, $extensionName, $arguments)) {
+                return $value;
+            }
         }
 
         if (null === $default || '' === $default) {

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Example for a SmartObject (Only one of the features)
 `Test.php`
 ```php
 namespace vendorName\extensionKey\Domain\Model;
+
+use HDNET\Autoloader\Annotation\DatabaseField;
+use HDNET\Autoloader\Annotation\DatabaseTable;
+
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 /**
  * Create a test-table for this model with this annotation.
@@ -59,7 +63,7 @@ class Test extends AbstractEntity {
 	 * A basic field
 	 *
 	 * @var string
-	 * @db
+	 * @DatabaseField(type="string")
 	 */
 	protected $textField;
 
@@ -67,7 +71,7 @@ class Test extends AbstractEntity {
 	 * A boolean field
 	 *
 	 * @var bool
-	 * @db
+	 * @DatabaseField(type="bool")
 	 */
 	protected $boolField;
 
@@ -75,7 +79,7 @@ class Test extends AbstractEntity {
 	 * File example
 	 *
 	 * @var \TYPO3\CMS\Extbase\Domain\Model\FileReference
-	 * @db
+	 * @DatabaseField(type="string")
 	 */
 	protected $file;
 
@@ -83,7 +87,7 @@ class Test extends AbstractEntity {
 	 * Custom (variable that has a custom DB type)
 	 *
 	 * @var int
-	 * @db int(11) DEFAULT '0' NOT NULL
+	 * @DatabaseField(type="string", sql="int(11) DEFAULT '0' NOT NULL")
 	 */
 	protected $customField;
 

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -8,6 +8,8 @@
 if (!defined('TYPO3_MODE')) {
     die('Access denied.');
 }
+// define TAB for XliffWriter template
+defined('TAB') ?: define('TAB', chr(9));
 
 \HDNET\Autoloader\Loader::extTables('HDNET', 'autoloader', [
     'Hooks',


### PR DESCRIPTION
Hey Tim, 
ich hatte eine Problem mit dem LanguageHandler. Teilweise wird der "assureLabel"-Hook aufgerufen ohne das es ein $GLOBALS['TYPO3_REQUEST'] gibt. Ich könnte mir vorstellen das der zu früh aufgerufen wird, sicher bin ich mir aber nicht. Ich habe deshalb eine Abfrage um das LocalizationUtility::translate() gelegt um zu verhindern das er versucht die SiteLanguage aufzurufen ohne das es einen "Request" gibt. Die Exception fliegt im LocalizationUtility Zeile 196-199 ($languageKeys['languageKey'] = $siteLanguage->getTypo3Language();)

Dazu habe ich die const TAB definiert da die im XliffWriter genutzt wird aber bei php 7.4 scheinbar nicht mehr deffiniert ist.

Und ich habe die readme.md angepasst was die Annotations angeht.

Gruß
Max