### PR TITLE
Allow empty dates in start- & endtime

### DIFF
--- a/Classes/DataSet/EnableFields.php
+++ b/Classes/DataSet/EnableFields.php
@@ -54,7 +54,7 @@ class EnableFields implements DataSetInterface
                     'config' => [
                         'type' => 'input',
                         'renderType' => 'inputDateTime',
-                        'eval' => 'datetime',
+                        'eval' => 'datetime,int',
                         'default' => 0,
                     ],
                     'l10n_mode' => 'exclude',
@@ -66,7 +66,7 @@ class EnableFields implements DataSetInterface
                     'config' => [
                         'type' => 'input',
                         'renderType' => 'inputDateTime',
-                        'eval' => 'datetime',
+                        'eval' => 'datetime,int',
                         'default' => 0,
                         'range' => [
                             'upper' => mktime(0, 0, 0, 1, 1, 2038),


### PR DESCRIPTION
Add int to evaluate empty values (e.g. '').
This fixes a problem, where you could not persist an empty string
(using a db in strict mode) in start- or endtime.
> SQL error: 'Incorrect integer value: ''

Similar to https://review.typo3.org/c/Packages/TYPO3.CMS/+/56062/