### PR TITLE
LanguageStore constructor has been extended in TYPO3 version 11.5.3

### DIFF
--- a/Classes/Loader/ContextSensitiveHelps.php
+++ b/Classes/Loader/ContextSensitiveHelps.php
@@ -108,8 +108,9 @@ class ContextSensitiveHelps implements LoaderInterface
     protected function checkCshValues($extensionKey, $table, array $properties)
     {
         $baseFileName = 'locallang_csh_'.$table;
-        /** @var LanguageHandler $languageHandler */
-        $languageHandler = GeneralUtility::makeInstance(LanguageHandler::class);
+        
+        $packageManager = GeneralUtility::makeInstance(PackageManager::class);
+        $languageHandler = new LanguageHandler($packageManager);
         foreach ($properties as $property) {
             $default = '';
             $languageHandler->handle($property.'.alttitle', $extensionKey, $default, null, $baseFileName);

--- a/Classes/Loader/ContextSensitiveHelps.php
+++ b/Classes/Loader/ContextSensitiveHelps.php
@@ -14,6 +14,7 @@ use HDNET\Autoloader\Service\SmartObjectInformationService;
 use HDNET\Autoloader\SmartObjectRegister;
 use HDNET\Autoloader\Utility\ClassNamingUtility;
 use HDNET\Autoloader\Utility\ModelUtility;
+use TYPO3\CMS\Core\Package\PackageManager;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 

--- a/Classes/Loader/ContextSensitiveHelps.php
+++ b/Classes/Loader/ContextSensitiveHelps.php
@@ -17,6 +17,7 @@ use HDNET\Autoloader\Utility\ModelUtility;
 use TYPO3\CMS\Core\Package\PackageManager;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 
 /**
  * ContextSensitiveHelp (CSH) based on smart objects.
@@ -109,9 +110,15 @@ class ContextSensitiveHelps implements LoaderInterface
     protected function checkCshValues($extensionKey, $table, array $properties)
     {
         $baseFileName = 'locallang_csh_'.$table;
+        if (version_compare(VersionNumberUtility::getCurrentTypo3Version(), '11.5.2', '<=')){
+            /** @var LanguageHandler $languageHandler */
+            $languageHandler = GeneralUtility::makeInstance(LanguageHandler::class);
+        } else {
+            $packageManager = GeneralUtility::makeInstance(PackageManager::class);
+            /** @var LanguageHandler $languageHandler */
+            $languageHandler = GeneralUtility::makeInstance(LanguageHandler::class, $packageManager);
+        }
         
-        $packageManager = GeneralUtility::makeInstance(PackageManager::class);
-        $languageHandler = new LanguageHandler($packageManager);
         foreach ($properties as $property) {
             $default = '';
             $languageHandler->handle($property.'.alttitle', $extensionKey, $default, null, $baseFileName);


### PR DESCRIPTION
After a TYPO3 update from version 11.5.2 to 11.5.3 the following error occurred: 

`(1/1) ArgumentCountError 
Too few arguments to function TYPO3\CMS\Core\Localization\LanguageStore::__construct(), 0 passed in /app/public/typo3/sysext/core/Classes/Utility/GeneralUtility.php on line 3199 and exactly 1 expected`

The argument PackageManager has been added.