### PR TITLE
[BUGFIX] TypeError regarding LanguageHandler.php

### DIFF
--- a/Classes/Loader/ContextSensitiveHelps.php
+++ b/Classes/Loader/ContextSensitiveHelps.php
@@ -118,7 +118,7 @@ class ContextSensitiveHelps implements LoaderInterface
 
         foreach ($properties as $property) {
             $default = '';
-            $languageHandler->handle($property . '.alttitle', $extensionKey, $default, null, $baseFileName);
+            $languageHandler->handle($property . '.alttitle', $extensionKey, $default, [], $baseFileName);
         }
 
         $checkPath = ['xlf', 'xml'];


### PR DESCRIPTION
LanguageHandler's handle method expects the fourth argument as an array, otherwise TypeError exception occurs.