### PR TITLE
Update size (width) of TCA inputs

### DIFF
--- a/Classes/DataSet/Workspaces.php
+++ b/Classes/DataSet/Workspaces.php
@@ -32,7 +32,6 @@ class Workspaces implements DataSetInterface
                     'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.versionLabel',
                     'config' => [
                         'type' => 'input',
-                        'size' => 30,
                         'max' => 255,
                     ],
                 ],

--- a/Classes/Mapper/DateTimeMapper.php
+++ b/Classes/Mapper/DateTimeMapper.php
@@ -42,7 +42,6 @@ class DateTimeMapper implements MapperInterface
                 'type' => 'input',
                 'renderType' => 'inputDateTime',
                 'eval' => 'datetime',
-                'size' => 8,
             ],
         ];
     }

--- a/Classes/Mapper/FloatMapper.php
+++ b/Classes/Mapper/FloatMapper.php
@@ -44,7 +44,7 @@ class FloatMapper implements MapperInterface
             'config' => [
                 'type' => 'input',
                 'eval' => 'double2',
-                'size' => 8,
+                'size' => 10,
             ],
         ];
     }

--- a/Classes/Mapper/IntMapper.php
+++ b/Classes/Mapper/IntMapper.php
@@ -44,7 +44,7 @@ class IntMapper implements MapperInterface
             'config' => [
                 'type' => 'input',
                 'eval' => 'int',
-                'size' => 8,
+                'size' => 10,
             ],
         ];
     }


### PR DESCRIPTION
The size (width) of input elements must be between 10 and 50.
See https://docs.typo3.org/m/typo3/reference-tca/11.5/en-us/ColumnsConfig/Type/Input/Properties/Size.html