### PR TITLE
fix TYPO3_REQUEST check

### DIFF
--- a/Classes/Localization/LanguageHandler.php
+++ b/Classes/Localization/LanguageHandler.php
@@ -49,7 +49,7 @@ class LanguageHandler extends LanguageStore
         }
 
         // LocalizationUtility::translate() throws exception if $GLOBALS['TYPO3_REQUEST'] is not instanceof ServerRequestInterface.
-        if ($GLOBALS['TYPO3_REQUEST'] instanceof ServerRequestInterface && ($value = LocalizationUtility::translate($key, $extensionName, $arguments))) {
+        if (isset($GLOBALS['TYPO3_REQUEST']) && $GLOBALS['TYPO3_REQUEST'] instanceof ServerRequestInterface && ($value = LocalizationUtility::translate($key, $extensionName, $arguments))) {
             return $value;
         }
 


### PR DESCRIPTION
See https://www.php.net/manual/en/migration80.incompatible.php

[...]

A number of notices have been converted into warnings:

[...]

* Attempting to read an undefined array key.